### PR TITLE
Powershell Port

### DIFF
--- a/Add-NoDelete.ps1
+++ b/Add-NoDelete.ps1
@@ -1,0 +1,6 @@
+# replaces [ADDON] with [NODELETE][ADDON] in all folder names
+Get-ChildItem -Path . -Filter "[ADDON]*" | Rename-Item -NewName { $_.Name -Replace '\[ADDON]','[NODELETE][ADDON]'}
+
+Set-Location ..\profiles
+# replaces [ADDON] with [NODELETE][ADDON] in all places it occurs within all the modlist.txt files in profiles folder
+Get-ChildItem -Path ".\*" -Include modlist.txt -Recurse | ForEach-Object {(Get-Content $_.FullName) -iReplace '\[ADDON]','[NODELETE][ADDON]' | Set-Content $_.FullName}

--- a/Remove-Addon.ps1
+++ b/Remove-Addon.ps1
@@ -1,0 +1,10 @@
+if ( (Read-Host -Prompt "This will remove all [ADDON] tags from folder names and modlist.txt, are you sure? Type y to continue ") -notmatch "[yY]" ) {
+    Exit
+}
+
+# remove [ADDON] in all folder names
+Get-ChildItem -Path . -Filter "[ADDON]*" | Rename-Item -NewName { $_.Name -Replace '\[ADDON]',''}
+
+Set-Location ..\profiles
+# remove [ADDON] in all places it occurs within all the modlist.txt files in profiles folder
+Get-ChildItem -Path ".\*" -Include modlist.txt -Recurse | ForEach-Object {(Get-Content $_.FullName) -iReplace '\[ADDON]','' | Set-Content $_.FullName}

--- a/Remove-NoDelete.ps1
+++ b/Remove-NoDelete.ps1
@@ -1,0 +1,6 @@
+# replaces [NODELETE][ADDON] with [ADDON] in all folder names
+Get-ChildItem -Path . -Filter "[NODELETE][ADDON]*" | Rename-Item -NewName { $_.Name -Replace '\[NODELETE]\[ADDON]','[ADDON]'}
+
+Set-Location ..\profiles
+# replaces [NODELETE][ADDON] with [ADDON] in all places it occurs within all the modlist.txt files in profiles folder
+Get-ChildItem -Path ".\*" -Include modlist.txt -Recurse | ForEach-Object {(Get-Content $_.FullName) -iReplace '\[NODELETE]\[ADDON]','[ADDON]' | Set-Content $_.FullName}


### PR DESCRIPTION
Direct Powershell ported the Bash files.
Users are required to have ExecutionPolicy set to Unrestricted or Bypass for the duration when they activate the script, but I assume most Powershell users will know that.